### PR TITLE
Updated the Bootstrap URL.

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <script src="http://code.angularjs.org/angular-1.0.0rc12.min.js"></script>
     <script type="text/javascript" src="app.js"></script>
 
-    <link rel="stylesheet" href="http://twitter.github.com/bootstrap/assets/css/bootstrap.css">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
     <link rel="stylesheet" href="app.css">
 
     <title>AngularJS Sticky Notes</title>


### PR DESCRIPTION
The bootstrap link was no longer working. Version 2.3.2 is no longer supported. Updated it to Bootstrap 3